### PR TITLE
fix: correct kubernetes module paths and containerd config

### DIFF
--- a/ec2-instance/main.tf
+++ b/ec2-instance/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   }
 
   tags = merge(var.tags, {
-    Name = format("%s-%02d", var.name_prefix, count.index)
+    Name = format("%s-%02d", var.name_prefix, count.index + 1)
   })
 }
 

--- a/kubernetes/cluster/README.md
+++ b/kubernetes/cluster/README.md
@@ -1,0 +1,35 @@
+# Kubernetes Cluster Module
+
+This module provisions the infrastructure for a small Kubernetes cluster on EC2 instances. It ships with two bootstrap scripts that prepare instances to run Kubernetes and join them together.
+
+## Bootstrap Scripts
+
+The `templates` directory contains Bash templates rendered by Terraform as user data for the control plane and worker nodes. Both scripts share common setup steps and differ in how they initialise or join the cluster.
+
+### Shared setup
+
+Both scripts perform the following actions:
+
+1. **Install base packages.** Update apt repositories and install tools such as `curl`, `awscli`, and transport certificates required for subsequent downloads.
+2. **Disable swap and load kernel modules.** Kubernetes requires swap to be disabled. The scripts also load `overlay` and `br_netfilter` modules and configure sysctl settings to allow IP forwarding and bridged IPv4/IPv6 traffic.
+3. **Install and configure containerd.** Containerd is installed from the Docker apt repository. A default configuration is generated and patched so that the cgroup driver uses `systemd`, which matches the kubelet's expectations. The service is then enabled and restarted.
+4. **Install Kubernetes components.** The scripts add the official Kubernetes apt repository, install `kubelet`, `kubeadm`, and `kubectl`, and mark them on hold to avoid unintended upgrades.
+
+### Control plane script
+
+`bootstrap-control-plane.sh.tpl` performs additional steps to bring up the cluster:
+
+1. **Initialise the control plane.** Runs `kubeadm init` with the provided pod CIDR to create a single‑node control plane.
+2. **Configure kubectl access.** Copies `/etc/kubernetes/admin.conf` to the invoking user's kubeconfig so `kubectl` can manage the cluster.
+3. **Install a CNI plugin.** Applies the Flannel manifest to provide pod networking across nodes.
+4. **Publish the worker join command.** Generates a `kubeadm token` join command and uploads it to an S3 bucket under `<cluster_name>/join.sh` for workers to consume.
+
+### Worker script
+
+`bootstrap-worker.sh.tpl` waits for the control plane to be ready and then joins the cluster:
+
+1. **Retrieve the join script.** Polls the same S3 bucket for `join.sh` produced by the control plane script.
+2. **Join the cluster.** Once available, marks the script executable and executes it, which runs `kubeadm join` with the token and discovery information.
+
+With these scripts, the control plane node initialises the cluster and publishes the join instructions, while worker nodes configure themselves and join when the instructions become available.
+

--- a/kubernetes/cluster/main.tf
+++ b/kubernetes/cluster/main.tf
@@ -18,7 +18,8 @@ locals {
 }
 
 module "sg" {
-  source                = "../kthw-security"
+  source                = "../security"
+  cluster_name          = var.cluster_name
   vpc_id                = var.vpc_id
   ssh_ingress_cidrs     = var.ssh_ingress_cidrs
   api_ingress_cidrs     = var.api_ingress_cidrs
@@ -96,7 +97,7 @@ locals {
 }
 
 module "control_plane" {
-  source                = "../ec2-instance"
+  source                = "../../ec2-instance"
   name_prefix           = "${var.cluster_name}-cp"
   ami_id                = var.ami_id
   instance_type         = var.control_plane_instance_type
@@ -112,7 +113,7 @@ module "control_plane" {
 }
 
 module "workers" {
-  source                = "../ec2-instance"
+  source                = "../../ec2-instance"
   name_prefix           = "${var.cluster_name}-worker"
   ami_id                = var.ami_id
   instance_type         = var.worker_instance_type

--- a/kubernetes/cluster/templates/bootstrap-control-plane.sh.tpl
+++ b/kubernetes/cluster/templates/bootstrap-control-plane.sh.tpl
@@ -32,7 +32,9 @@ echo \
 apt-get update && apt-get install -y containerd.io
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
 systemctl enable --now containerd
+systemctl restart containerd
 
 # Kubernetes packages
 curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg

--- a/kubernetes/cluster/templates/bootstrap-worker.sh.tpl
+++ b/kubernetes/cluster/templates/bootstrap-worker.sh.tpl
@@ -32,7 +32,9 @@ echo \
 apt-get update && apt-get install -y containerd.io
 mkdir -p /etc/containerd
 containerd config default | tee /etc/containerd/config.toml
+sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
 systemctl enable --now containerd
+systemctl restart containerd
 
 # Kubernetes packages
 curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg

--- a/kubernetes/security/main.tf
+++ b/kubernetes/security/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "aws_security_group" "control_plane" {
-  name        = "kthw-control-plane"
+  name        = "${var.cluster_name}-control-plane"
   description = "Control plane SG for Kubernetes"
   vpc_id      = var.vpc_id
 
@@ -20,11 +20,11 @@ resource "aws_security_group" "control_plane" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(var.tags, { Name = "kthw-control-plane" })
+  tags = merge(var.tags, { Name = "${var.cluster_name}-control-plane" })
 }
 
 resource "aws_security_group" "worker" {
-  name        = "kthw-worker"
+  name        = "${var.cluster_name}-worker"
   description = "Worker SG for Kubernetes"
   vpc_id      = var.vpc_id
 
@@ -35,7 +35,7 @@ resource "aws_security_group" "worker" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(var.tags, { Name = "kthw-worker" })
+  tags = merge(var.tags, { Name = "${var.cluster_name}-worker" })
 }
 
 # SSH to both groups

--- a/kubernetes/security/variables.tf
+++ b/kubernetes/security/variables.tf
@@ -3,6 +3,11 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "cluster_name" {
+  description = "Identifier for the Kubernetes cluster to prefix resource names."
+  type        = string
+}
+
 variable "ssh_ingress_cidrs" {
   description = "CIDR blocks allowed to SSH."
   type        = list(string)


### PR DESCRIPTION
## Summary
- start EC2 instance Name tags at 1
- fix Kubernetes module paths and pass cluster name to submodules
- prefix security group names with cluster name to avoid collisions
- ensure control plane and worker bootstrap scripts enable systemd cgroup for containerd
- document bootstrap scripts for control plane and worker nodes

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `tflint --version` *(fails: command not found)*
- `cd kubernetes/cluster && terraform init && terraform validate` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y terraform` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c57d937dcc832abcd9b8782b2216d1